### PR TITLE
Handle non-mapped LFN information

### DIFF
--- a/xrootdlib/examples/XrdXrootdMon/pretty_print.py
+++ b/xrootdlib/examples/XrdXrootdMon/pretty_print.py
@@ -1,3 +1,4 @@
+from typing import Union
 import argparse
 import time
 import socket
@@ -6,7 +7,7 @@ import collections
 import chainlet
 
 from xrootdlib.streams.XrdXrootdMon import stream_packets, map_streams, Packet
-from xrootdlib.streams.XrdXrootdMon.map import ServerInfo, UserInfo
+from xrootdlib.streams.XrdXrootdMon.map import ServerInfo, UserInfo, PathAccessInfo
 from xrootdlib.streams.XrdXrootdMon.redir import RedirWindow
 from xrootdlib.streams.XrdXrootdMon.fstat import FstatWindow, Transfer
 from xrootdlib.streams.XrdXrootdMon.trace import TraceWindow
@@ -50,10 +51,13 @@ def site_id(server: ServerInfo):
     )
 
 
-def pretty_user(user: UserInfo):
+def pretty_user(user: Union[UserInfo, PathAccessInfo]):
     """Format a user identifier"""
+    def decode(raw) -> str:
+        return raw.decode() if raw is not None else "<unknown>"
+
     return '{user}@{host}({pid}) [{protocol}]'.format(
-        user=user.user.decode(), host=user.host.decode(), pid=user.pid, protocol=user.protocol.decode()
+        user=decode(user.user), host=decode(user.host), pid=user.pid, protocol=decode(user.protocol)
     )
 
 

--- a/xrootdlib/examples/XrdXrootdMon/pretty_print.py
+++ b/xrootdlib/examples/XrdXrootdMon/pretty_print.py
@@ -104,7 +104,7 @@ def print_fstat(value):
         for idx, record in enumerate(value.records):
             if type(record) == Transfer:
                 continue
-            print(' %4dF' % idx, '{:<10}'.format(type(record).__name__), record.lfn.decode() if hasattr(record, 'lfn') else '')
+            print(' %4dF' % idx, '{:<10}'.format(type(record).__name__), getattr(record, 'lfn', b'').decode())
             print('      ', pretty_user(record.client))
     return value
 

--- a/xrootdlib/streams/XrdXrootdMon/fstat.py
+++ b/xrootdlib/streams/XrdXrootdMon/fstat.py
@@ -29,16 +29,15 @@ class Open(object):
         self.readwrite, self.filesize, self.client, self.lfn = readwrite, filesize, client, lfn
 
     @classmethod
-    def from_record(cls, record_struct: FileOPN, stod: int, map_store: MapInfoStore):
+    def from_record(cls, record_struct: FileOPN, server: ServerInfo, map_store: MapInfoStore):
         read_write = bool(record_struct.flags & recFval.hasRW)
         if record_struct.user is None:
-            # the record does not store the user/lfn – get it from the map stream
-            path_info = map_store.get_access(stod, record_struct.fileid)
-            return cls(path_info, path_info.path, read_write, record_struct.filesize)
+            # the record does not store the user/lfn – get it from the map
+            access_info = map_store.get_access(server.stod, record_struct.fileid)
         else:
-            # the record does provide the user/lfn – put it into the map stream
-            client = map_store.get_user(stod, record_struct.user) if record_struct.user > 0 else None
-            return cls(client, record_struct.lfn, read_write, record_struct.filesize)
+            # the record does provide the user/lfn – put it into the map
+            access_info = map_store.set_access(server, record_struct.fileid, record_struct.user, record_struct.lfn)
+        return cls(access_info, access_info.path, read_write, record_struct.filesize)
 
 
 class Close(object):

--- a/xrootdlib/streams/XrdXrootdMon/fstat.py
+++ b/xrootdlib/streams/XrdXrootdMon/fstat.py
@@ -25,7 +25,7 @@ class Open(object):
     """A client opened a file"""
     __slots__ = ('client', 'lfn', 'readwrite', 'filesize')
 
-    def __init__(self, client: Union[UserInfo, PathAccessInfo], lfn: bytes, readwrite: bool, filesize: int):
+    def __init__(self, client: PathAccessInfo, lfn: bytes, readwrite: bool, filesize: int):
         self.readwrite, self.filesize, self.client, self.lfn = readwrite, filesize, client, lfn
 
     @classmethod
@@ -44,7 +44,7 @@ class Close(object):
     """A client closed a file"""
     __slots__ = ('client', 'lfn', 'stats')
 
-    def __init__(self, client: Union[UserInfo, PathAccessInfo], lfn: bytes, stats: FileCLS):
+    def __init__(self, client: PathAccessInfo, lfn: bytes, stats: FileCLS):
         self.client, self.lfn, self.stats = client, lfn, stats
 
     @classmethod
@@ -58,7 +58,7 @@ class Transfer(object):
     """A client transfered a file"""
     __slots__ = ('client', 'lfn', 'stats')
 
-    def __init__(self, client: Union[UserInfo, PathAccessInfo], lfn: bytes, stats: FileXFR):
+    def __init__(self, client: PathAccessInfo, lfn: bytes, stats: FileXFR):
         self.client, self.lfn, self.stats = client, lfn, stats
 
     @classmethod

--- a/xrootdlib/streams/XrdXrootdMon/fstat.py
+++ b/xrootdlib/streams/XrdXrootdMon/fstat.py
@@ -15,9 +15,9 @@ class Disconnect(object):
         self.client = client
 
     @classmethod
-    def from_record(cls, record_struct: FileDSC, stod: int, map_store: MapInfoStore):
-        client = map_store.get_user(stod, record_struct.dictid)
-        map_store.free_user(stod, record_struct.dictid)
+    def from_record(cls, record_struct: FileDSC, server: ServerInfo, map_store: MapInfoStore):
+        client = map_store.get_user(server.stod, record_struct.dictid)
+        map_store.free_user(server.stod, record_struct.dictid)
         return cls(client)
 
 
@@ -49,9 +49,9 @@ class Close(object):
         self.client, self.lfn, self.stats = client, lfn, stats
 
     @classmethod
-    def from_record(cls, record_struct: FileCLS, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_access(stod, record_struct.fileid)
-        map_store.free_access(stod, record_struct.fileid)
+    def from_record(cls, record_struct: FileCLS, server: ServerInfo, map_store: MapInfoStore):
+        path_info = map_store.get_access(server.stod, record_struct.fileid)
+        map_store.free_access(server.stod, record_struct.fileid)
         return cls(path_info, path_info.path, record_struct)
 
 
@@ -63,9 +63,9 @@ class Transfer(object):
         self.client, self.lfn, self.stats = client, lfn, stats
 
     @classmethod
-    def from_record(cls, record_struct: FileXFR, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_access(stod, record_struct.fileid)
-        map_store.free_access(stod, record_struct.fileid)
+    def from_record(cls, record_struct: FileXFR, server: ServerInfo, map_store: MapInfoStore):
+        path_info = map_store.get_access(server.stod, record_struct.fileid)
+        map_store.free_access(server.stod, record_struct.fileid)
         return cls(path_info, path_info.path, record_struct)
 
 
@@ -103,7 +103,7 @@ def digest_packet(stod: int, fstat_struct: FstatStruct, map_store: MapInfoStore)
     for record_struct in fstat_struct.records:
         converter = convert_record_dispatch[type(record_struct)]
         try:
-            record = converter(record_struct, stod, map_store)
+            record = converter(record_struct, server_info, map_store)
         except MapInfoError:
             continue
         records.append(record)

--- a/xrootdlib/streams/XrdXrootdMon/fstat.py
+++ b/xrootdlib/streams/XrdXrootdMon/fstat.py
@@ -31,12 +31,12 @@ class Open(object):
     @classmethod
     def from_record(cls, record_struct: FileOPN, stod: int, map_store: MapInfoStore):
         read_write = bool(record_struct.flags & recFval.hasRW)
-        if record_struct.user is not None:
-            client = map_store.get_user(stod, record_struct.user)
-            return cls(client, record_struct.lfn, read_write, record_struct.filesize)
-        else:
+        if record_struct.user is None:
             path_info = map_store.get_path(stod, record_struct.fileid)
             return cls(path_info, path_info.path, read_write, record_struct.filesize)
+        else:
+            client = map_store.get_user(stod, record_struct.user)
+            return cls(client, record_struct.lfn, read_write, record_struct.filesize)
 
 
 class Close(object):

--- a/xrootdlib/streams/XrdXrootdMon/fstat.py
+++ b/xrootdlib/streams/XrdXrootdMon/fstat.py
@@ -32,10 +32,12 @@ class Open(object):
     def from_record(cls, record_struct: FileOPN, stod: int, map_store: MapInfoStore):
         read_write = bool(record_struct.flags & recFval.hasRW)
         if record_struct.user is None:
-            path_info = map_store.get_path(stod, record_struct.fileid)
+            # the record does not store the user/lfn – get it from the map stream
+            path_info = map_store.get_access(stod, record_struct.fileid)
             return cls(path_info, path_info.path, read_write, record_struct.filesize)
         else:
-            client = map_store.get_user(stod, record_struct.user)
+            # the record does provide the user/lfn – put it into the map stream
+            client = map_store.get_user(stod, record_struct.user) if record_struct.user > 0 else None
             return cls(client, record_struct.lfn, read_write, record_struct.filesize)
 
 
@@ -48,8 +50,8 @@ class Close(object):
 
     @classmethod
     def from_record(cls, record_struct: FileCLS, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_path(stod, record_struct.fileid)
-        map_store.free_path(stod, record_struct.fileid)
+        path_info = map_store.get_access(stod, record_struct.fileid)
+        map_store.free_access(stod, record_struct.fileid)
         return cls(path_info, path_info.path, record_struct)
 
 
@@ -62,8 +64,8 @@ class Transfer(object):
 
     @classmethod
     def from_record(cls, record_struct: FileXFR, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_path(stod, record_struct.fileid)
-        map_store.free_path(stod, record_struct.fileid)
+        path_info = map_store.get_access(stod, record_struct.fileid)
+        map_store.free_access(stod, record_struct.fileid)
         return cls(path_info, path_info.path, record_struct)
 
 

--- a/xrootdlib/streams/XrdXrootdMon/map.py
+++ b/xrootdlib/streams/XrdXrootdMon/map.py
@@ -56,25 +56,31 @@ class UserInfo(object):
 
 
 class PathAccessInfo(object):
+    """
+    Metadata of a ``client`` accessing a ``path`` on a ``server``
+
+    Depending on the monitoring settings, ``client`` and ``auth`` may be unavailable
+    and just :py:data:`None`.
+    """
     __slots__ = ('client', 'server', 'path', 'auth')
 
     @property
     def protocol(self):
-        return self.client.prot
+        return self.client.prot if self.client is not None else None
 
     @property
     def user(self):
-        return self.client.user
+        return self.client.user if self.client is not None else None
 
     @property
     def pid(self):
-        return self.client.pid
+        return self.client.pid if self.client is not None else None
 
     @property
     def host(self):
-        return self.client.host
+        return self.client.host if self.client is not None else None
 
-    def __init__(self, client: UserId, server: ServerInfo, path: bytes, auth: Optional[AuthInfo] = None):
+    def __init__(self, client: Optional[UserId], server: ServerInfo, path: bytes, auth: Optional[AuthInfo] = None):
         self.client = client
         self.server = server
         self.path = path

--- a/xrootdlib/streams/XrdXrootdMon/map.py
+++ b/xrootdlib/streams/XrdXrootdMon/map.py
@@ -11,9 +11,9 @@ from ...utility import slot_repr
 
 
 class ServerInfo(object):
-    __slots__ = ('protocol', 'user', 'pid', 'sid', 'host', 'program', 'version', 'instance', 'port', 'site')
+    __slots__ = ('protocol', 'user', 'pid', 'sid', 'host', 'program', 'version', 'instance', 'port', 'site', 'stod')
 
-    def __init__(self, user_id: UserId, server_info: SrvInfo):
+    def __init__(self, user_id: UserId, server_info: SrvInfo, stod: int):
         self.protocol = user_id.prot
         self.user = user_id.user
         self.pid = user_id.pid
@@ -24,6 +24,7 @@ class ServerInfo(object):
         self.instance = server_info.inst
         self.port = server_info.port
         self.site = server_info.site
+        self.stod = stod
 
     __repr__ = slot_repr
 
@@ -138,7 +139,7 @@ class MapInfoStore(object):
             pass
         else:
             self._cleaner.add_deletion(self._server_info.pop, deprecated_sid, None)
-        server_info = self._server_info[stod, user_id.sid] = ServerInfo(user_id, server_info)
+        server_info = self._server_info[stod, user_id.sid] = ServerInfo(user_id, server_info, stod)
         return server_info
 
     def get_user(self, stod: int, dictid: int) -> UserInfo:

--- a/xrootdlib/streams/XrdXrootdMon/map.py
+++ b/xrootdlib/streams/XrdXrootdMon/map.py
@@ -151,10 +151,14 @@ class MapInfoStore(object):
     def free_user(self, stod: int, dictid: int) -> None:
         self._cleaner.add_deletion(self._user_info.pop, (stod, dictid), None)
 
-    def set_access(self, stod: int, dictid: int, userid: int, path: bytes) -> PathAccessInfo:
-        """Add a file access info based on an FStat Open with LFN"""
-        user_info = self.get_user(stod, userid)
-        item = self._access_info[stod, dictid] = PathAccessInfo(user_info.user_id, user_info.server, path, user_info.auth_info)
+    def set_access(self, server: ServerInfo, dictid: int, userid: int, path: bytes) -> PathAccessInfo:
+        """Add a file access info based on raw references (i.e. FStat Open with LFN)"""
+        if userid > 0:
+            user = self.get_user(server.stod, userid)
+            client, auth = user.client, user.auth_info
+        else:
+            client, auth = None, None
+        item = self._access_info[server.stod, dictid] = PathAccessInfo(client, server, path, auth)
         return item
 
     def get_access(self, stod: int, dictid: int) -> PathAccessInfo:

--- a/xrootdlib/streams/XrdXrootdMon/map.py
+++ b/xrootdlib/streams/XrdXrootdMon/map.py
@@ -29,14 +29,27 @@ class ServerInfo(object):
 
 
 class UserInfo(object):
-    __slots__ = ('protocol', 'user', 'pid', 'server', 'host', 'auth_info')
+    __slots__ = ('user_id', 'server', 'auth_info')
+
+    @property
+    def protocol(self):
+        return self.user_id.prot
+
+    @property
+    def user(self):
+        return self.user_id.user
+
+    @property
+    def pid(self):
+        return self.user_id.pid
+
+    @property
+    def host(self):
+        return self.user_id.host
 
     def __init__(self, user_id: UserId, server_info: ServerInfo, auth_info: AuthInfo = None):
-        self.protocol = user_id.prot
-        self.user = user_id.user
-        self.pid = user_id.pid
+        self.user_id = user_id
         self.server = server_info
-        self.host = user_id.host
         self.auth_info = auth_info
 
     __repr__ = slot_repr

--- a/xrootdlib/streams/XrdXrootdMon/trace.py
+++ b/xrootdlib/streams/XrdXrootdMon/trace.py
@@ -35,7 +35,7 @@ class Open(object):
 
     @classmethod
     def from_record(cls, record_struct: OpenStruct, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_path(stod, record_struct.dictid)
+        path_info = map_store.get_access(stod, record_struct.dictid)
         return cls(path_info, path_info.path, record_struct.filesize)
 
     __repr__ = slot_repr
@@ -50,7 +50,7 @@ class ReadWrite(object):
 
     @classmethod
     def from_record(cls, record_struct: ReadWriteStruct, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_path(stod, record_struct.dictid)
+        path_info = map_store.get_access(stod, record_struct.dictid)
         if record_struct.buflen > 0:
             read, write = record_struct.buflen, 0
         else:
@@ -76,8 +76,8 @@ class Close(object):
 
     @classmethod
     def from_record(cls, record_struct: CloseStruct, stod: int, map_store: MapInfoStore):
-        path_info = map_store.get_path(stod, record_struct.dictid)
-        map_store.free_path(stod, record_struct.dictid)
+        path_info = map_store.get_access(stod, record_struct.dictid)
+        map_store.free_access(stod, record_struct.dictid)
         return cls(path_info, path_info.path, record_struct.rtot, record_struct.wtot)
 
     __repr__ = slot_repr

--- a/xrootdlib/structs/XrdXrootdMon/fstat.py
+++ b/xrootdlib/structs/XrdXrootdMon/fstat.py
@@ -76,7 +76,7 @@ class FileDSC(object):
     struct_parser = struct.Struct('!B B h L')
     size = struct_parser.size
 
-    def __init__(self, flags: int, dictid: str):
+    def __init__(self, flags: int, dictid: int):
         self.flags, self.dictid = flags, dictid
 
     @classmethod

--- a/xrootdlib/structs/XrdXrootdMon/fstat.py
+++ b/xrootdlib/structs/XrdXrootdMon/fstat.py
@@ -99,6 +99,12 @@ class FileOPN(object):
     :param filesize: size of the file in bytes
     :param user: client identifier (see :py:class:`~xrootdlib.structs.XrdXrootdMon.Map`)
     :param lfn: the (logical) path of the file
+
+    The ``fileid``, ``user`` and ``lfn`` are closely related and should be interpreted
+    together. If not ``rec_flag & hasLFN`` then ``fileid`` points to user info that
+    contains both ``user`` and ``lfn`` information. Otherwise, the user info should be
+    constructed from ``user`` and ``lfn`` information for the given ``fileid`` as the
+    corresponding :py:class:`~.FileCLS` expects this information.
     """
     __slots__ = ('flags', 'size', 'fileid', 'filesize', 'user', 'lfn')
     struct_parser = struct.Struct('!B B h L q')


### PR DESCRIPTION
This PR adjusts the mapping between streams when LFN/User information is provided in the F-Stream only.

* Adjusted the layout of User/Access info to allow optional fields and conversion
* Reconstructing FStat ``Open`` may add an access info if it's not in the map stream

Closes #1.